### PR TITLE
[CIR-2310] HttpClientV2 improvements

### DIFF
--- a/app/uk/gov/hmrc/cipphonenumberverification/config/GuiceModule.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/config/GuiceModule.scala
@@ -49,12 +49,4 @@ class GuiceModule(environment: Environment, config: Configuration) extends Abstr
     } else {
       new LiveSendCodeService(verificationCodeGenerator, auditService, verificationCodeService, validateService, userNotificationsConnector, metricsService)
     }
-
-  @Provides
-  @Named("internal-http-client")
-  def provideInternalHttpClient(
-    wsClient: WSClient,
-    actorSystem: ActorSystem
-  ): HttpClientV2 =
-    new HttpClientV2Impl(wsClient, actorSystem, config, Seq())
 }

--- a/app/uk/gov/hmrc/cipphonenumberverification/connectors/UserNotificationsConnector.scala
+++ b/app/uk/gov/hmrc/cipphonenumberverification/connectors/UserNotificationsConnector.scala
@@ -29,10 +29,7 @@ import javax.inject.{Inject, Named, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class UserNotificationsConnector @Inject() (
-  @Named("internal-http-client") httpClient: HttpClientV2,
-  config: AppConfig
-)(implicit ec: ExecutionContext) {
+class UserNotificationsConnector @Inject() (httpClient: HttpClientV2, config: AppConfig)(implicit ec: ExecutionContext) {
 
   import VerificationCodeNotificationRequest.Implicits._
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,9 +19,6 @@ include "backend.conf"
 
 appName = phone-number-verification
 
-# Http client
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
-
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,13 +2,13 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapPlayVersion = "9.19.0"
+  private val bootstrapPlayVersion = "10.1.0"
   private val playSuffix           = "-play-30"
   private val mongoVersion         = "2.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"                  %% s"bootstrap-backend$playSuffix"    % bootstrapPlayVersion,
-    "uk.gov.hmrc"                  %% s"internal-auth-client$playSuffix" % "1.10.0",
+    "uk.gov.hmrc"                  %% s"internal-auth-client$playSuffix" % "4.1.0",
     "uk.gov.hmrc.mongo"            %% s"hmrc-mongo$playSuffix"           % mongoVersion,
     "com.googlecode.libphonenumber" % "libphonenumber"                   % "9.0.12"
   )


### PR DESCRIPTION
- change to use bootstrap provided default module instead of custom HttpClientV2 instance that removed AuditHooks
- includes some dependency upgrades